### PR TITLE
Fix #7: ideal start times

### DIFF
--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -100,8 +100,8 @@ Savings Time. These time slots are as follows, in UTC:
 | Name | Times (Northern Summer) | Times (Northern Winter) |
 | ---- | ----------------------- | ----------------------- |
 | North America Night | 0500-1100 | 0600-1200 |
-| Asia Night | 1400-2000 | 1600-2200 |
-| Europe Night | 2200-0400 | 0000-0600 |
+| Asia Night | 1400-2000 | 1500-2100 |
+| Europe Night | 2200-0400 | 2200-0400 |
 
 The intent of rotating between these three slots is to scatter meetings
 throughout the course of the global day, to maximize the ease of participants

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -99,9 +99,9 @@ Savings Time. These time slots are as follows, in UTC:
 
 | Name | Times (Northern Summer) | Times (Northern Winter) |
 | ---- | ----------------------- | ----------------------- |
-| North America Night | 0500-1100 | 0600-1200 |
-| Asia Night | 1400-2000 | 1500-2100 |
-| Europe Night | 2200-0400 | 2200-0400 |
+| North America Night | 0500-1100 UTC | 0600-1200 UTC |
+| Asia Night | 1400-2000 UTC | 1500-2100 UTC |
+| Europe Night | 2200-0400 UTC | 2200-0400 UTC |
 
 The intent of rotating between these three slots is to scatter meetings
 throughout the course of the global day, to maximize the ease of participants

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -124,6 +124,10 @@ one of those regions.
 | In-Person A | In-Person B | Remote B Night | A Night |
 | In-Person A | In-Person A | Remote A Night | see below |
 
+Basically this table follows two rules:
+1) Even ever a fully online meeting follows and in-person meeting, the online meeting that is used that disadvantages most the participants of the time zone where the in-person meeting was held.
+2) If multiple fully online meetings follow each other, the time zone selection should be rotated based on the most recent time zones that the in-person meetings were held in.
+
 The final case occurs in the rare event that back-to-back in-person plenaries
 occur in the same region. In this case, find the most recent meeting that was
 neither in 'A' (if in person) nor in 'A' night (if remote). If this meeting

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -88,34 +88,41 @@ following this 1-1-1 rule to share the pain has/seems to have rough consensus.
 
 ## Time Zone Selection
 
-All fully online IETF plenary meetings begin at 0500 ("Asia"), 1200 ("Europe"), or 2100 ("North America") UTC. The names
-are not meant to imply that all participants in a given region will find the times convenient given their personal
-schedules, but are useful for the selection rules below. These location names are consistent with the venue
-selection criteria in {{RFC8719}}.
+All fully online IETF plenary meetings begin at 0500 ("North America Night"),
+1400 ("Asia Night"), or 2200 ("Europe Night") UTC. The times are not meant to
+optimize for any region listed in the selection criteria in {{RFC8179}}.
+Instead, their intent is for any meeting to mostly occur during the day of two
+RFC8179 regions, so that only one meeting per year has overnight hours for a
+given region.
 
-The selected slots have been proposed to minimize inconvenience while not excessively penalizing any time zone.
-Effectively, there is an early morning and a late afternoon meeting for two of the three regions in
-each slot. E.g. the "Asia" 0500 UTC slot would be 0600 CET (early morning) and 1300 China Standard Time (afternoon). Since fully
-online meeting days are expected to be shorter then in-person meetings, this slot is roughly within the "usual" working hours
-of both regions.
-
-The intent of rotating between these three slots is to scatter meetings throughout the course of the global day, to maximize the ease
-of participants to occasionally attend regardless of their location and what time of day is optimal for their schedule.
+The intent of rotating between these three slots is to scatter meetings
+throughout the course of the global day, to maximize the ease of participants
+to occasionally attend regardless of their location and what time of day is
+optimal for their schedule.
 
 ### Rules for selection
 
-The IETF will select a start time from these three choices according the following rules, applied in order.
+The IETF will select a start time from these three choices based on the past
+three meetings. The following table covers all permutations of previous
+meetings held in-person in Region A, B, or C; or remotely in the nights of
+one of those regions.
 
-1. Eliminate all regions that had an in-person meeting in that calendar year. If one region remains, select the time
-slot mapped to that region.
+| 3 meetings ago | 2 meetings ago | Last Meeting | Remote Selection |
+| -------------- | -------------- | ------------ | ---------------- |
+| Any | Any | In-Person, A | A Night |
+| Any | Remote, A Night | Remote, B Night | C Night |
+| Remote A Night | In-Person B | Remote B Night | C Night |
+| In-Person A | In-Person B | Remote B Night | A Night |
+| In-Person A | In-Person A | Remote A Night | see below |
 
-2. Eliminate all regions that have a planned in-person meeting that calendar year. If one region remains, select the
-time slot mapped to that region.
+The final case occurs in the rare event that back-to-back in-person plenaries
+occur in the same region. In this case, find the most recent meeting that was
+neither in 'A' (if in person) nor in 'A' night (if remote). If this meeting
+was in-person in region 'B', then the next meeting will be in 'B' Night. If it
+was remote in 'B' Night, the next meeting will be in 'C' Night.
 
-3. Select the region that has least recently had an fully online IETF plenary in its slot. For the pandemic cancellations
-of 2020- 2021, the original host cities are used to determine the host region. Therefore, at the time of writing the
-most recent selections are Asia in November 2020, Europe in March 2021, and North America in July 2021.
-
+To initialize this algorithm, IETF 112 is considered as an 'Asia Night'
+remote meeting, and IETF 111 is a 'Europe Night' remote meeting.
 
 ## Number of Days and Total Hours per Day
 

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -25,7 +25,7 @@ author:
 
 
 normative:
-  RFC8719: 
+  RFC8719:
 
 
 informative:
@@ -90,7 +90,7 @@ following this 1-1-1 rule to share the pain has/seems to have rough consensus.
 
 This time selection enables to have 2 out of 3 fully online IETF plenary meetings 
 during the day from most participants. Basically every full online meeting is for two regions 
-of the three regions described in {{RFC8179}}, roughly speaking, after sunrise or after dinner.
+of the three regions described in {{!RFC8179}}, roughly speaking, after sunrise or after dinner.
 This has the tradeoff that it maps the third region in middle of night. However, that also means
 for most participants only one remote meeting per year might
 require a significant change to sleep schedules.

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -116,13 +116,14 @@ three meetings. The following table covers all permutations of previous
 meetings held in-person in Region A, B, or C; or remotely in the nights of
 one of those regions.
 
-| 3 meetings ago | 2 meetings ago | Last Meeting | Remote Selection |
+| 3 meetings ago | 2 meetings ago | Last Meeting | Online Selection |
 | -------------- | -------------- | ------------ | ---------------- |
-| Any | Any | In-Person, A | A Night |
-| Any | Remote, A Night | Remote, B Night | C Night |
-| Remote A Night | In-Person B | Remote B Night | C Night |
-| In-Person A | In-Person B | Remote B Night | A Night |
-| In-Person A | In-Person A | Remote A Night | see below |
+| Any | Any | In-Person A | A Night |
+| Any | Online A Night | Online B Night | C Night |
+| Online A Night | In-Person B | Online B Night | C Night |
+| In-Person A | In-Person B | Online B Night | A Night |
+| In-Person A | In-Person A | Online A Night | see below |
+| Online A Night | Online B Night | Online C Night | A Night |
 
 Basically this table follows two rules:
 1) Even ever a fully online meeting follows and in-person meeting, the online meeting that is used that disadvantages most the participants of the time zone where the in-person meeting was held.

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -88,12 +88,20 @@ following this 1-1-1 rule to share the pain has/seems to have rough consensus.
 
 ## Time Zone Selection
 
-All fully online IETF plenary meetings begin at 0500 ("North America Night"),
-1400 ("Asia Night"), or 2200 ("Europe Night") UTC. The times are not meant to
-optimize for any region listed in the selection criteria in {{RFC8179}}.
-Instead, their intent is for any meeting to mostly occur during the day of two
-RFC8179 regions, so that only one meeting per year has overnight hours for a
-given region.
+All fully online IETF plenary meetings are at a time that maps to the middle of
+the night in one of the three regions described in {{RFC8179}}, so that in the
+other two regions they occur mostly after sunrise or after dinner, roughly
+speaking. Thus, for most participants only one remote meeting per year might
+require a major change to sleep schedules.
+
+The times are also seasonally adjusted to leverage differentials in Daylight
+Savings Time. These time slots are as follows, in UTC:
+
+| Name | Times (Northern Summer) | Times (Northern Winter) |
+| ---- | ----------------------- | ----------------------- |
+| North America Night | 0500-1100 | 0600-1200 |
+| Asia Night | 1400-2000 | 1600-2200 |
+| Europe Night | 2200-0400 | 0000-0600 |
 
 The intent of rotating between these three slots is to scatter meetings
 throughout the course of the global day, to maximize the ease of participants

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -88,11 +88,12 @@ following this 1-1-1 rule to share the pain has/seems to have rough consensus.
 
 ## Time Zone Selection
 
-All fully online IETF plenary meetings are at a time that maps to the middle of
-the night in one of the three regions described in {{RFC8179}}, so that in the
-other two regions they occur mostly after sunrise or after dinner, roughly
-speaking. Thus, for most participants only one remote meeting per year might
-require a major change to sleep schedules.
+This time selection enables to have 2 out of 3 fully online IETF plenary meetings 
+during the day from most participants. Basically every full online meeting is for two regions 
+of the three regions described in {{RFC8179}}, roughly speaking, after sunrise or after dinner.
+This has the tradeoff that it maps the third region in middle of night. However, that also means
+for most participants only one remote meeting per year might
+require a significant change to sleep schedules.
 
 The times are also seasonally adjusted to leverage differentials in Daylight
 Savings Time. These time slots are as follows, in UTC:

--- a/draft-kuehlewind-shmoo-online-meeting.md
+++ b/draft-kuehlewind-shmoo-online-meeting.md
@@ -126,7 +126,7 @@ one of those regions.
 | Online A Night | Online B Night | Online C Night | A Night |
 
 Basically this table follows two rules:
-1) Even ever a fully online meeting follows and in-person meeting, the online meeting that is used that disadvantages most the participants of the time zone where the in-person meeting was held.
+1) When ever a fully online meeting follows and in-person meeting, the online meeting time is used that disadvantages most the participants of the time zone where the in-person meeting was held.
 2) If multiple fully online meetings follow each other, the time zone selection should be rotated based on the most recent time zones that the in-person meetings were held in.
 
 The final case occurs in the rare event that back-to-back in-person plenaries


### PR DESCRIPTION
Since the time slots are now optimized to exclude one region than be good for one and bad for two, the selection rules had to change as well.